### PR TITLE
Fix 'moment' dependency version that was too low

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"jspm" : {
 		"main": "builds/moment-timezone-with-data",
 		"dependencies": {
-			"moment": "~2.6.0"
+			"moment": ">= 2.9.0"
 		},
 		"shim": {
 			"moment-timezone": {


### PR DESCRIPTION
The current code requires >= 2.9.0 actually.
